### PR TITLE
adopted hnsw index and fixed incorrect sql queries

### DIFF
--- a/benchmark_pg_vector.py
+++ b/benchmark_pg_vector.py
@@ -48,7 +48,7 @@ def setup_database():
     cur.execute("CREATE INDEX ON documents USING HNSW (vector vector_l2_ops);")
     cur.execute("CREATE INDEX ON documents USING HNSW (vector vector_cosine_ops);")
     cur.execute("CREATE INDEX ON documents USING HNSW (vector vector_ip_ops);")
-    # conn.commit()
+    conn.commit()
 
     return cur, conn
 


### PR DESCRIPTION
Replaced ivfflat to hnsw indices.
The <#> operator returns negative inner product, fixed the inner product query.
The cosine similarity should be used by subtracting it from 1 i.e. 1 - (vector <=> '[3,1,2]') as score.